### PR TITLE
cmdvel_to_ackermann confused track_width and wheel_base

### DIFF
--- a/humble_ws/src/ackermann_control/cmdvel_to_ackermann/launch/cmdvel_to_ackermann.launch.py
+++ b/humble_ws/src/ackermann_control/cmdvel_to_ackermann/launch/cmdvel_to_ackermann.launch.py
@@ -20,22 +20,41 @@ from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        DeclareLaunchArgument("publish_period_ms", default_value="20", description="publishing dt in milliseconds"),
-        DeclareLaunchArgument("track_width", default_value="0.24", description="wheel separation distance (m)"),
-        DeclareLaunchArgument("acceleration", default_value="0.0", description="acceleration, 0 means change speed as quickly as possible (ms^-2)"),
-        DeclareLaunchArgument("steering_velocity", default_value="0.0", description="delta steering angle, 0 means change angle as quickly as possible (radians/s)"),
-        
-        Node(
-            package='cmdvel_to_ackermann',
-            executable='cmdvel_to_ackermann.py',
-            name='cmdvel_to_ackermann',
-            output="screen",
-            parameters=[{
-                'publish_period_ms': LaunchConfiguration('publish_period_ms'),
-                'track_width': LaunchConfiguration('track_width'),
-                'acceleration': LaunchConfiguration('acceleration'),
-                'steering_velocity': LaunchConfiguration('steering_velocity')
-            }]
-        ),
-    ])
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "publish_period_ms",
+                default_value="20",
+                description="publishing dt in milliseconds",
+            ),
+            DeclareLaunchArgument(
+                "wheel_base",
+                default_value="0.24",
+                description="front-to-rear axle distance (m)",
+            ),
+            DeclareLaunchArgument(
+                "acceleration",
+                default_value="0.0",
+                description="acceleration, 0 means change speed as quickly as possible (ms^-2)",
+            ),
+            DeclareLaunchArgument(
+                "steering_velocity",
+                default_value="0.0",
+                description="delta steering angle, 0 means change angle as quickly as possible (radians/s)",
+            ),
+            Node(
+                package="cmdvel_to_ackermann",
+                executable="cmdvel_to_ackermann.py",
+                name="cmdvel_to_ackermann",
+                output="screen",
+                parameters=[
+                    {
+                        "publish_period_ms": LaunchConfiguration("publish_period_ms"),
+                        "wheel_base": LaunchConfiguration("wheel_base"),
+                        "acceleration": LaunchConfiguration("acceleration"),
+                        "steering_velocity": LaunchConfiguration("steering_velocity"),
+                    }
+                ],
+            ),
+        ]
+    )

--- a/humble_ws/src/ackermann_control/cmdvel_to_ackermann/scripts/cmdvel_to_ackermann.py
+++ b/humble_ws/src/ackermann_control/cmdvel_to_ackermann/scripts/cmdvel_to_ackermann.py
@@ -24,44 +24,50 @@ from rclpy.node import Node
 
 
 class CmdvelToAckermann(Node):
-    """Subscribe to the Twist message and converts it to AckermannDrive message and publish.
-    """
+    """Subscribe to the Twist message and converts it to AckermannDrive message and publish."""
 
     def __init__(self):
-        super().__init__('cmdvel_to_ackermann')
+        super().__init__("cmdvel_to_ackermann")
 
-        self.declare_parameter('publish_period_ms', 20)
-        self.declare_parameter('track_width', 0.24)
-        self.declare_parameter('acceleration', 0.0)
-        self.declare_parameter('steering_velocity', 0.0)
-        
-        self._cmd_vel_subscription = self.create_subscription(Twist, '/cmd_vel',
-                                                              self._cmd_vel_callback, 1)
-        self._ackermann_publisher = self.create_publisher(AckermannDriveStamped, '/ackermann_cmd',
-                                                          1)
-        publish_period_ms = self.get_parameter(
-            'publish_period_ms').value / 1000
+        self.declare_parameter("publish_period_ms", 20)
+        self.declare_parameter("wheel_base", 0.24)
+        self.declare_parameter("acceleration", 0.0)
+        self.declare_parameter("steering_velocity", 0.0)
+
+        self._cmd_vel_subscription = self.create_subscription(
+            Twist, "/cmd_vel", self._cmd_vel_callback, 1
+        )
+        self._ackermann_publisher = self.create_publisher(
+            AckermannDriveStamped, "/ackermann_cmd", 1
+        )
+        publish_period_ms = self.get_parameter("publish_period_ms").value / 1000
         self.create_timer(publish_period_ms, self._timer_callback)
-        self.track_width = self.get_parameter("track_width").value
+        self.wheel_base = self.get_parameter("wheel_base").value
         self.acceleration = self.get_parameter("acceleration").value
         self.steering_velocity = self.get_parameter("steering_velocity").value
 
-        self.get_logger().info(f"track_width: {self.track_width}")
+        if self.wheel_base <= 0.0:
+            self.get_logger().warn(
+                f"Invalid wheel_base {self.wheel_base}. Falling back to 0.24 m."
+            )
+            self.wheel_base = 0.24
+
+        self.get_logger().info(f"wheel_base: {self.wheel_base}")
         self.get_logger().info(f"acceleration: {self.acceleration}")
         self.get_logger().info(f"steering_velocity: {self.steering_velocity}")
         self._ackermann_msg = None
-        
 
     def _convert_trans_rot_vel_to_steering_angle(self, v, omega) -> float:
         if omega == 0 or v == 0:
             if omega != 0:
                 self.get_logger().warn(
-                    f'Invalid command for ackermann drive with zero vel {v} but non zero '
-                    f'omega {omega}')
+                    f"Invalid command for ackermann drive with zero vel {v} but non zero "
+                    f"omega {omega}"
+                )
             return 0.0
 
         turning_radius = v / omega
-        return math.atan(self.track_width / turning_radius)
+        return math.atan(self.wheel_base / turning_radius)
 
     def _cmd_vel_callback(self, msg):
         self._ackermann_msg = AckermannDriveStamped()
@@ -69,7 +75,8 @@ class CmdvelToAckermann(Node):
         # Conversion logic (simplified example)
         self._ackermann_msg.drive.speed = msg.linear.x
         steering_angle = self._convert_trans_rot_vel_to_steering_angle(
-            self._ackermann_msg.drive.speed, msg.angular.z)
+            self._ackermann_msg.drive.speed, msg.angular.z
+        )
         self._ackermann_msg.drive.steering_angle = steering_angle
         self._ackermann_msg.drive.acceleration = self.acceleration
         self._ackermann_msg.drive.steering_angle_velocity = self.steering_velocity
@@ -87,5 +94,5 @@ def main(args=None):
     rclpy.shutdown()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/jazzy_ws/src/ackermann_control/cmdvel_to_ackermann/launch/cmdvel_to_ackermann.launch.py
+++ b/jazzy_ws/src/ackermann_control/cmdvel_to_ackermann/launch/cmdvel_to_ackermann.launch.py
@@ -20,22 +20,41 @@ from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        DeclareLaunchArgument("publish_period_ms", default_value="20", description="publishing dt in milliseconds"),
-        DeclareLaunchArgument("track_width", default_value="0.24", description="wheel separation distance (m)"),
-        DeclareLaunchArgument("acceleration", default_value="0.0", description="acceleration, 0 means change speed as quickly as possible (ms^-2)"),
-        DeclareLaunchArgument("steering_velocity", default_value="0.0", description="delta steering angle, 0 means change angle as quickly as possible (radians/s)"),
-        
-        Node(
-            package='cmdvel_to_ackermann',
-            executable='cmdvel_to_ackermann.py',
-            name='cmdvel_to_ackermann',
-            output="screen",
-            parameters=[{
-                'publish_period_ms': LaunchConfiguration('publish_period_ms'),
-                'track_width': LaunchConfiguration('track_width'),
-                'acceleration': LaunchConfiguration('acceleration'),
-                'steering_velocity': LaunchConfiguration('steering_velocity')
-            }]
-        ),
-    ])
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "publish_period_ms",
+                default_value="20",
+                description="publishing dt in milliseconds",
+            ),
+            DeclareLaunchArgument(
+                "wheel_base",
+                default_value="0.24",
+                description="front-to-rear axle distance (m)",
+            ),
+            DeclareLaunchArgument(
+                "acceleration",
+                default_value="0.0",
+                description="acceleration, 0 means change speed as quickly as possible (ms^-2)",
+            ),
+            DeclareLaunchArgument(
+                "steering_velocity",
+                default_value="0.0",
+                description="delta steering angle, 0 means change angle as quickly as possible (radians/s)",
+            ),
+            Node(
+                package="cmdvel_to_ackermann",
+                executable="cmdvel_to_ackermann.py",
+                name="cmdvel_to_ackermann",
+                output="screen",
+                parameters=[
+                    {
+                        "publish_period_ms": LaunchConfiguration("publish_period_ms"),
+                        "wheel_base": LaunchConfiguration("wheel_base"),
+                        "acceleration": LaunchConfiguration("acceleration"),
+                        "steering_velocity": LaunchConfiguration("steering_velocity"),
+                    }
+                ],
+            ),
+        ]
+    )

--- a/jazzy_ws/src/ackermann_control/cmdvel_to_ackermann/scripts/cmdvel_to_ackermann.py
+++ b/jazzy_ws/src/ackermann_control/cmdvel_to_ackermann/scripts/cmdvel_to_ackermann.py
@@ -24,44 +24,50 @@ from rclpy.node import Node
 
 
 class CmdvelToAckermann(Node):
-    """Subscribe to the Twist message and converts it to AckermannDrive message and publish.
-    """
+    """Subscribe to the Twist message and converts it to AckermannDrive message and publish."""
 
     def __init__(self):
-        super().__init__('cmdvel_to_ackermann')
+        super().__init__("cmdvel_to_ackermann")
 
-        self.declare_parameter('publish_period_ms', 20)
-        self.declare_parameter('track_width', 0.24)
-        self.declare_parameter('acceleration', 0.0)
-        self.declare_parameter('steering_velocity', 0.0)
-        
-        self._cmd_vel_subscription = self.create_subscription(Twist, '/cmd_vel',
-                                                              self._cmd_vel_callback, 1)
-        self._ackermann_publisher = self.create_publisher(AckermannDriveStamped, '/ackermann_cmd',
-                                                          1)
-        publish_period_ms = self.get_parameter(
-            'publish_period_ms').value / 1000
+        self.declare_parameter("publish_period_ms", 20)
+        self.declare_parameter("wheel_base", 0.24)
+        self.declare_parameter("acceleration", 0.0)
+        self.declare_parameter("steering_velocity", 0.0)
+
+        self._cmd_vel_subscription = self.create_subscription(
+            Twist, "/cmd_vel", self._cmd_vel_callback, 1
+        )
+        self._ackermann_publisher = self.create_publisher(
+            AckermannDriveStamped, "/ackermann_cmd", 1
+        )
+        publish_period_ms = self.get_parameter("publish_period_ms").value / 1000
         self.create_timer(publish_period_ms, self._timer_callback)
-        self.track_width = self.get_parameter("track_width").value
+        self.wheel_base = self.get_parameter("wheel_base").value
         self.acceleration = self.get_parameter("acceleration").value
         self.steering_velocity = self.get_parameter("steering_velocity").value
 
-        self.get_logger().info(f"track_width: {self.track_width}")
+        if self.wheel_base <= 0.0:
+            self.get_logger().warn(
+                f"Invalid wheel_base {self.wheel_base}. Falling back to 0.24 m."
+            )
+            self.wheel_base = 0.24
+
+        self.get_logger().info(f"wheel_base: {self.wheel_base}")
         self.get_logger().info(f"acceleration: {self.acceleration}")
         self.get_logger().info(f"steering_velocity: {self.steering_velocity}")
         self._ackermann_msg = None
-        
 
     def _convert_trans_rot_vel_to_steering_angle(self, v, omega) -> float:
         if omega == 0 or v == 0:
             if omega != 0:
                 self.get_logger().warn(
-                    f'Invalid command for ackermann drive with zero vel {v} but non zero '
-                    f'omega {omega}')
+                    f"Invalid command for ackermann drive with zero vel {v} but non zero "
+                    f"omega {omega}"
+                )
             return 0.0
 
         turning_radius = v / omega
-        return math.atan(self.track_width / turning_radius)
+        return math.atan(self.wheel_base / turning_radius)
 
     def _cmd_vel_callback(self, msg):
         self._ackermann_msg = AckermannDriveStamped()
@@ -69,7 +75,8 @@ class CmdvelToAckermann(Node):
         # Conversion logic (simplified example)
         self._ackermann_msg.drive.speed = msg.linear.x
         steering_angle = self._convert_trans_rot_vel_to_steering_angle(
-            self._ackermann_msg.drive.speed, msg.angular.z)
+            self._ackermann_msg.drive.speed, msg.angular.z
+        )
         self._ackermann_msg.drive.steering_angle = steering_angle
         self._ackermann_msg.drive.acceleration = self.acceleration
         self._ackermann_msg.drive.steering_angle_velocity = self.steering_velocity
@@ -87,5 +94,5 @@ def main(args=None):
     rclpy.shutdown()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi I came across the following issue where I would propose some changes:

## Summary
This PR fixes the steering-angle conversion in `cmdvel_to_ackermann` by using `wheel_base` (axle distance) instead of `track_width` (left-right wheel separation).

## Why
For Ackermann/bicycle-model steering:
- Turning radius is `R = v / ω`
- Steering angle is `δ = atan(L / R)`, where `L` is the wheelbase

Using `track_width` in this formula produces incorrect steering commands.

## Changes
- Updated steering computation to:
  - `steering_angle = atan(wheel_base / turning_radius)`
- Removed backward-compatibility logic for `track_width`
- Removed `track_width` parameter declarations and usages from node scripts and launch files
- Standardized parameter interface to `wheel_base` only

## Impact
- **Breaking change:** `track_width` is no longer accepted by `cmdvel_to_ackermann`
- Users must pass `wheel_base` in launch/config files

## Validation
- Verified no remaining `track_width` references in the `cmdvel_to_ackermann` package
- Diagnostics report no errors in edited files