### PR TITLE
Fixing param issues in multi robot scenario

### DIFF
--- a/jazzy_ws/src/navigation/carter_navigation/params/office/multi_robot_carter_navigation_params_1.yaml
+++ b/jazzy_ws/src/navigation/carter_navigation/params/office/multi_robot_carter_navigation_params_1.yaml
@@ -38,7 +38,7 @@ amcl:
     z_rand: 0.5
     z_short: 0.05
     scan_topic: /carter1/scan
-    map_topic: /carter2/map
+    map_topic: /carter1/map
     set_initial_pose: true
     always_reset_initial_pose: false
     first_map_only: false
@@ -283,7 +283,7 @@ local_costmap:
         mark_threshold: 0
         observation_sources: scan
         scan:
-          topic: /scan
+          topic: /carter1/scan
           max_obstacle_height: 2.0
           clearing: True
           marking: True

--- a/jazzy_ws/src/navigation/carter_navigation/params/office/multi_robot_carter_navigation_params_2.yaml
+++ b/jazzy_ws/src/navigation/carter_navigation/params/office/multi_robot_carter_navigation_params_2.yaml
@@ -283,7 +283,7 @@ local_costmap:
         mark_threshold: 0
         observation_sources: scan
         scan:
-          topic: /scan
+          topic: /carter2/scan
           max_obstacle_height: 2.0
           clearing: True
           marking: True

--- a/jazzy_ws/src/navigation/carter_navigation/params/office/multi_robot_carter_navigation_params_3.yaml
+++ b/jazzy_ws/src/navigation/carter_navigation/params/office/multi_robot_carter_navigation_params_3.yaml
@@ -283,7 +283,7 @@ local_costmap:
         mark_threshold: 0
         observation_sources: scan
         scan:
-          topic: /scan
+          topic: /carter3/scan
           max_obstacle_height: 2.0
           clearing: True
           marking: True


### PR DESCRIPTION
Changes
Namespaced scan_topic: Updated all lidar sensor sources (including 2D and 3D layers) to use the specific robot namespace (e.g., /carter1/scan). 

Corrected map_topic: Updated the AMCL configuration to ensure Robot 1 is subscribing to its own map topic (/carter1/map) rather than the current scenario where it uses just /map.