### PR TITLE
Bumped Isaac Sim and torch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [6.0.3] - 2026-06-10
+### Changed
+- Bumped versions for Isaac Sim pip dependency to 6.0.0.1.
+- Bumped versions for torch pip dependency to 2.11.0.
+
 ## [6.0.3] - 2026-06-09
 ### Changed
 - Pixi toml now adds Isaac Sim pip dependency.

--- a/jazzy_ws/pixi.toml
+++ b/jazzy_ws/pixi.toml
@@ -119,8 +119,8 @@ filelock = "*"
 
 # Install isaacsim with Pixi/uv
 [pypi-dependencies]
-isaacsim = { version = "==6.0.0", extras = ["all", "extscache", "ros2"]}
-torch = { version = "==2.10.0", index = "https://download.pytorch.org/whl/cu128" }
+isaacsim = { version = "==6.0.0.1", extras = ["all", "extscache", "ros2"]}
+torch = { version = "==2.11.0", index = "https://download.pytorch.org/whl/cu128" }
 
 
 [tasks]


### PR DESCRIPTION
- Bumped versions for Isaac Sim pip dependency to 6.0.0.1.
- Bumped versions for torch pip dependency to 2.11.0.